### PR TITLE
Use nbQA post-v1

### DIFF
--- a/Chapter7/jupyter_notebook.ipynb
+++ b/Chapter7/jupyter_notebook.ipynb
@@ -764,7 +764,7 @@
     "# pre-commit-config.yaml\n",
     "repos:\n",
     "- repo: https://github.com/nbQA-dev/nbQA\n",
-    "  rev: 0.10.0\n",
+    "  rev: 1.2.3\n",
     "  hooks:\n",
     "    - id: nbqa-flake8\n",
     "    - id: nbqa-isort\n",


### PR DESCRIPTION
Hey @khuyentran1401 ,

Thanks for including nbQA, much appreciated!

I'm just suggesting to include a post-version 1.0.0 version, as that's when the tool became a lot more stable / reliable

And please feel free to reach out if you have any feature requests and/or bug reports